### PR TITLE
update role to grand initial copy job access to the regional artifact…

### DIFF
--- a/templates/lex_bot_kendra_master.template.yaml
+++ b/templates/lex_bot_kendra_master.template.yaml
@@ -148,6 +148,25 @@ Resources:
           Action:
           - sts:AssumeRole
       Path: "/"
+      Policies:
+        - PolicyName: lambda-copier
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - "s3:PutObject"
+                  - "s3:ListObject"
+                Resource:
+                  - !Join
+                    - ''
+                    - - 'arn:aws:s3:::'
+                      - !Ref RegionalArtifactBucket
+                  - !Join
+                    - ''
+                    - - 'arn:aws:s3:::'
+                      - !Ref RegionalArtifactBucket
+                      - '/*'
 
   LambdaFunctionIAMPolicy:
     Type: AWS::IAM::Policy


### PR DESCRIPTION
… bucket

The initial copy job had no access to copy the data into the regional artifact bucket.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
